### PR TITLE
Add translations for multiple Spanish dialects

### DIFF
--- a/src/main/resources/data/goml/lang/es_ar.json
+++ b/src/main/resources/data/goml/lang/es_ar.json
@@ -1,0 +1,143 @@
+{
+  "itemGroup.goml.group": "Get Off My Lawn",
+
+  "block.goml.makeshift_claim_anchor": "Protección Improvisada",
+  "block.goml.reinforced_claim_anchor": "Protección Reforzada",
+  "block.goml.glistening_claim_anchor": "Protección Brillante",
+  "block.goml.crystal_claim_anchor": "Protección Cristalina",
+  "block.goml.emeradic_claim_anchor": "Protección Esmeraldina",
+  "block.goml.withered_claim_anchor": "Protección Marchita",
+  "block.goml.admin_claim_anchor": "Protección de Administrador",
+
+  "block.goml.anchor_augment": "Mejora de Protección: %s",
+
+  "block.goml.ender_binding": "Prisión del End",
+  "block.goml.ender_binding.description.1": "Endermans no podrán teletransportarse y",
+  "block.goml.ender_binding.description.2": "colocar bloques dentro de la protección.",
+
+  "block.goml.lake_spirit_grace": "Gracia del Espíritu del Lago",
+  "block.goml.lake_spirit_grace.description.1": "Todos los jugadores dentro de la protección reciben",
+  "block.goml.lake_spirit_grace.description.2": "los efectos de Respiración Acuática y Gracia Delfina.",
+
+  "block.goml.angelic_aura": "Aura Angelical",
+  "block.goml.angelic_aura.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.angelic_aura.description.2": "reciben el efecto de Regeneración.",
+
+  "block.goml.heaven_wings": "Alas del Cielo",
+  "block.goml.heaven_wings.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.heaven_wings.description.2": "reciben la habilidad de volar.",
+
+  "block.goml.village_core": "Núcleo de Aldea",
+  "block.goml.village_core.description.1": "Los aldeanos dentro de la protección",
+  "block.goml.village_core.description.2": "son protegidos del daño por criaturas hostiles.",
+
+  "block.goml.withering_seal": "Sello Marchito",
+  "block.goml.withering_seal.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.withering_seal.description.2": "son protegidos del efecto de descomposición (wither).",
+
+  "block.goml.chaos_zone": "Zona Caótica",
+  "block.goml.chaos_zone.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.chaos_zone.description.2": "reciben el efecto de Fuerza.",
+
+  "block.goml.defenders_right": "Derecho del Defensor",
+  "block.goml.defenders_right.description.1": "Todos las mascotas dentro de la protección",
+  "block.goml.defenders_right.description.2": "infligen daño extra a sus enemigos.",
+
+  "block.goml.greeter": "Saludador",
+  "block.goml.greeter.description.1": "Envía un mensaje de bienvenida a los jugadores",
+  "block.goml.greeter.description.2": "cuando entran en la protección",
+
+  "block.goml.pvp_arena": "Arena PvP",
+  "block.goml.pvp_arena.description.1": "Activa o desactiva el daño entre jugadores",
+  "block.goml.pvp_arena.description.2": "dentro de la protección",
+
+  "block.goml.explosion_controller": "Control de Explosiones",
+  "block.goml.explosion_controller.description.1": "Activa o desactiva el daño causado por explosiones",
+  "block.goml.explosion_controller.description.2": "naturales (que no son causadas por jugadores).",
+
+  "item.goml.goggles": "Gafas Reveladoras (de Protección)",
+  "item.goml.reinforced_upgrade_kit": "Kit de Mejora Reforzada",
+  "item.goml.glistening_upgrade_kit": "Kit de Mejora Brillante",
+  "item.goml.crystal_upgrade_kit": "Kit de Mejora Cristalina",
+  "item.goml.emeradic_upgrade_kit": "Kit de Mejora Esmeraldina",
+  "item.goml.withered_upgrade_kit": "Kit de Mejora Marchita",
+
+  "text.goml.gui.input_greeting.title": "Saludo de Bienvenida",
+  "text.goml.gui.input_greeting.set": "Guardar cambios",
+  "text.goml.gui.input_greeting.close": "Cancelar cambios",
+  "text.goml.gui.next_page": "Página Siguiente",
+  "text.goml.gui.previous_page": "Página Anterior",
+  "text.goml.gui.close": "Cerrar",
+  "text.goml.gui.back": "Atrás",
+  "text.goml.gui.player_list.title": "Miembros",
+  "text.goml.gui.player_list.add_player": "Añadir Miembro",
+  "text.goml.gui.click_to_remove": "Clic para quitar al miembro de la protección",
+  "text.goml.gui.player_add_gui.title": "Añadir miembro a la protección",
+  "text.goml.gui.claim.title": "Protección",
+  "text.goml.gui.claim.about": "Información...",
+  "text.goml.gui.claim.players": "Miembros...",
+  "text.goml.gui.claim.augments": "Mejoras...",
+  "text.goml.gui.click_to_modify": "Clic para modificar la configuración...",
+  "text.goml.gui.admin_settings": "Modificar Protección de Admin...",
+  "text.goml.gui.augment_list.title": "Mejoras de Protección",
+  "text.goml.gui.admin_settings.title": "Modificar Protección de Admin",
+
+  "text.goml.mode.everyone": "Todos",
+  "text.goml.mode.trusted": "Sólo Miembros",
+  "text.goml.mode.untrusted": "Sólo No Miembros",
+  "text.goml.mode.disabled": "Desactivado",
+  "text.goml.mode.enabled": "Activado",
+  "text.goml.mode_toggle": "Modo: %s",
+  "text.goml.mode_toggle.help": "Clic para cambiar el modo actual",
+  "text.goml.explosion_control_toggle": "Prevenir Explosiones: %s",
+
+  "text.goml.augment": "Mejora: %s",
+
+  "text.goml.command.no_claims": "No te encuentras en ninguna protección!",
+  "text.goml.command.already_added": "El jugador %s ya es miembro de la protección!",
+  "text.goml.command.number_in": "Cantidad de protecciones en %s: %s",
+  "text.goml.command.number_all": "Cantidad de protecciones en todos los mundos: %s",
+  "text.goml.command.owner_added": "%s ha sido añadido como dueño de esta protección.",
+  "text.goml.command.owner_removed": "%s ha sido removido como dueño de esta protección.",
+  "text.goml.command.trusted": "%s ha sido añadido como miembro de esta protección.",
+  "text.goml.command.untrusted": "%s ha sido removido como miembro de esta protección",
+  "text.goml.command.add_self": "Ya tienes permisos en la protección!",
+  "text.goml.command.remove_self": "No puedes removerte a ti mismo de esta protección!",
+  "text.goml.command.removed_claim": "La protección en %s con origen %s ha sido removida.",
+
+  "text.goml.block_protected": "Este bloque se encuentra protegido!",
+  "text.goml.entity_protected": "Esta entidad se encuentra protegida!",
+  "text.goml.area_protected": "Esta área se encuentra protegida!",
+
+  "text.goml.cant_place_claim.max_count_reached": "No puedes tener más protecciones! Ya tienes %s protecciones!",
+  "text.goml.cant_place_claim.blacklisted_area": "No puedes proteger en el mundo %s en %s! Esta área se encuentra en la lista negra!",
+  "text.goml.cant_place_claim.collides_with": "No puedes proteger aquí porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+  "text.goml.cant_place_claim.admin_only": "No puedes crear esa protección, primero debes activar el Modo Admin!",
+
+  "text.goml.cant_upgrade_claim.collides_with": "No puedes mejorar esta protección porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+
+  "text.goml.command.help.help": "muestra este mensaje.",
+  "text.goml.command.help.info": "muestra información acerca de la protección en tu posición actual.",
+  "text.goml.command.help.addowner": "añade un dueño a la protección en tu posición actual.",
+  "text.goml.command.help.trust": "añade un miembro a la protección en tu posición actual.",
+  "text.goml.command.help.untrust": "remueve un miembro de la protección en tu posición actual.",
+  "text.goml.command.help.list": "muestra todas las protecciones en las que tienes permisos.",
+  "text.goml.command.help.gui": "muestra el menú de la protección en tu posición actual.",
+  "text.goml.command.help.admin": "muestra todo los comandos relacionados con administración.",
+
+  "text.goml.position": "Posición: %s",
+  "text.goml.radius": "Radio: %s",
+  "text.goml.height": "Altura: %s",
+  "text.goml.owners": "Dueños: %s",
+  "text.goml.trusted": "Miembros: %s",
+  "text.goml.your_claims": "Tus protecciones",
+  "text.goml.someones_claims": "Protecciones de %s",
+  "text.goml.owner": "Dueño",
+  "text.goml.apply": "Aplicar cambios",
+
+  "text.goml.admin_mode.enabled": "Se activó el Modo Admin! Ahora puedes modificar las protecciones de otros jugadores!",
+  "text.goml.admin_mode.disabled": "Se desactivó el Modo Admin! Ya no puedes modificar las protecciones de otros jugadores!",
+
+  "text.goml.changed_greeting": "El saludo de bienvenida de tu protección ahora es: %s",
+  "text.goml.disabled_augment": "Este objeto se encuentra desactivado!"
+}

--- a/src/main/resources/data/goml/lang/es_cl.json
+++ b/src/main/resources/data/goml/lang/es_cl.json
@@ -1,0 +1,143 @@
+{
+  "itemGroup.goml.group": "Get Off My Lawn",
+
+  "block.goml.makeshift_claim_anchor": "Protección Improvisada",
+  "block.goml.reinforced_claim_anchor": "Protección Reforzada",
+  "block.goml.glistening_claim_anchor": "Protección Brillante",
+  "block.goml.crystal_claim_anchor": "Protección Cristalina",
+  "block.goml.emeradic_claim_anchor": "Protección Esmeraldina",
+  "block.goml.withered_claim_anchor": "Protección Marchita",
+  "block.goml.admin_claim_anchor": "Protección de Administrador",
+
+  "block.goml.anchor_augment": "Mejora de Protección: %s",
+
+  "block.goml.ender_binding": "Prisión del End",
+  "block.goml.ender_binding.description.1": "Endermans no podrán teletransportarse y",
+  "block.goml.ender_binding.description.2": "colocar bloques dentro de la protección.",
+
+  "block.goml.lake_spirit_grace": "Gracia del Espíritu del Lago",
+  "block.goml.lake_spirit_grace.description.1": "Todos los jugadores dentro de la protección reciben",
+  "block.goml.lake_spirit_grace.description.2": "los efectos de Respiración Acuática y Gracia del Delfín.",
+
+  "block.goml.angelic_aura": "Aura Angelical",
+  "block.goml.angelic_aura.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.angelic_aura.description.2": "reciben el efecto de Regeneración.",
+
+  "block.goml.heaven_wings": "Alas del Cielo",
+  "block.goml.heaven_wings.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.heaven_wings.description.2": "reciben la habilidad de volar.",
+
+  "block.goml.village_core": "Núcleo de Aldea",
+  "block.goml.village_core.description.1": "Los aldeanos dentro de la protección",
+  "block.goml.village_core.description.2": "son protegidos del daño por mobs hostiles.",
+
+  "block.goml.withering_seal": "Sello Marchito",
+  "block.goml.withering_seal.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.withering_seal.description.2": "son protegidos del efecto de wither.",
+
+  "block.goml.chaos_zone": "Zona Caótica",
+  "block.goml.chaos_zone.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.chaos_zone.description.2": "reciben el efecto de Fuerza.",
+
+  "block.goml.defenders_right": "Derecho del Defensor",
+  "block.goml.defenders_right.description.1": "Todos las mascotas dentro de la protección",
+  "block.goml.defenders_right.description.2": "infligen daño extra a sus enemigos.",
+
+  "block.goml.greeter": "Saludador",
+  "block.goml.greeter.description.1": "Envía un mensaje de bienvenida a los jugadores",
+  "block.goml.greeter.description.2": "cuando entran en la protección",
+
+  "block.goml.pvp_arena": "Arena PvP",
+  "block.goml.pvp_arena.description.1": "Activa o desactiva el daño entre jugadores",
+  "block.goml.pvp_arena.description.2": "dentro de la protección",
+
+  "block.goml.explosion_controller": "Control de Explosiones",
+  "block.goml.explosion_controller.description.1": "Activa o desactiva el daño causado por explosiones",
+  "block.goml.explosion_controller.description.2": "naturales (que no son causadas por jugadores).",
+
+  "item.goml.goggles": "Gafas Reveladoras (de Protección)",
+  "item.goml.reinforced_upgrade_kit": "Kit de Mejora Reforzada",
+  "item.goml.glistening_upgrade_kit": "Kit de Mejora Brillante",
+  "item.goml.crystal_upgrade_kit": "Kit de Mejora Cristalina",
+  "item.goml.emeradic_upgrade_kit": "Kit de Mejora Esmeraldina",
+  "item.goml.withered_upgrade_kit": "Kit de Mejora Marchita",
+
+  "text.goml.gui.input_greeting.title": "Saludo de Bienvenida",
+  "text.goml.gui.input_greeting.set": "Guardar cambios",
+  "text.goml.gui.input_greeting.close": "Cancelar cambios",
+  "text.goml.gui.next_page": "Página Siguiente",
+  "text.goml.gui.previous_page": "Página Anterior",
+  "text.goml.gui.close": "Cerrar",
+  "text.goml.gui.back": "Atrás",
+  "text.goml.gui.player_list.title": "Miembros",
+  "text.goml.gui.player_list.add_player": "Añadir Miembro",
+  "text.goml.gui.click_to_remove": "Clic para quitar al miembro de la protección",
+  "text.goml.gui.player_add_gui.title": "Añadir miembro a la protección",
+  "text.goml.gui.claim.title": "Protección",
+  "text.goml.gui.claim.about": "Información...",
+  "text.goml.gui.claim.players": "Miembros...",
+  "text.goml.gui.claim.augments": "Mejoras...",
+  "text.goml.gui.click_to_modify": "Clic para modificar la configuración...",
+  "text.goml.gui.admin_settings": "Modificar Protección de Admin...",
+  "text.goml.gui.augment_list.title": "Mejoras de Protección",
+  "text.goml.gui.admin_settings.title": "Modificar Protección de Admin",
+
+  "text.goml.mode.everyone": "Todos",
+  "text.goml.mode.trusted": "Sólo Miembros",
+  "text.goml.mode.untrusted": "Sólo No Miembros",
+  "text.goml.mode.disabled": "Desactivado",
+  "text.goml.mode.enabled": "Activado",
+  "text.goml.mode_toggle": "Modo: %s",
+  "text.goml.mode_toggle.help": "Clic para cambiar el modo actual",
+  "text.goml.explosion_control_toggle": "Prevenir Explosiones: %s",
+
+  "text.goml.augment": "Mejora: %s",
+
+  "text.goml.command.no_claims": "No te encuentras en ninguna protección!",
+  "text.goml.command.already_added": "El jugador %s ya es miembro de la protección!",
+  "text.goml.command.number_in": "Cantidad de protecciones en %s: %s",
+  "text.goml.command.number_all": "Cantidad de protecciones en todos los mundos: %s",
+  "text.goml.command.owner_added": "%s ha sido añadido como dueño de esta protección.",
+  "text.goml.command.owner_removed": "%s ha sido removido como dueño de esta protección.",
+  "text.goml.command.trusted": "%s ha sido añadido como miembro de esta protección.",
+  "text.goml.command.untrusted": "%s ha sido removido como miembro de esta protección",
+  "text.goml.command.add_self": "Ya tienes permisos en la protección!",
+  "text.goml.command.remove_self": "No puedes removerte a ti mismo de esta protección!",
+  "text.goml.command.removed_claim": "La protección en %s con origen %s ha sido removida.",
+
+  "text.goml.block_protected": "Este bloque se encuentra protegido!",
+  "text.goml.entity_protected": "Esta entidad se encuentra protegida!",
+  "text.goml.area_protected": "Esta área se encuentra protegida!",
+
+  "text.goml.cant_place_claim.max_count_reached": "No puedes tener más protecciones! Ya tienes %s protecciones!",
+  "text.goml.cant_place_claim.blacklisted_area": "No puedes proteger en el mundo %s en %s! Esta área se encuentra en la lista negra!",
+  "text.goml.cant_place_claim.collides_with": "No puedes proteger aquí porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+  "text.goml.cant_place_claim.admin_only": "No puedes crear esa protección, primero debes activar el Modo Admin!",
+
+  "text.goml.cant_upgrade_claim.collides_with": "No puedes mejorar esta protección porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+
+  "text.goml.command.help.help": "muestra este mensaje.",
+  "text.goml.command.help.info": "muestra información acerca de la protección en tu posición actual.",
+  "text.goml.command.help.addowner": "añade un dueño a la protección en tu posición actual.",
+  "text.goml.command.help.trust": "añade un miembro a la protección en tu posición actual.",
+  "text.goml.command.help.untrust": "remueve un miembro de la protección en tu posición actual.",
+  "text.goml.command.help.list": "muestra todas las protecciones en las que tienes permisos.",
+  "text.goml.command.help.gui": "muestra el menú de la protección en tu posición actual.",
+  "text.goml.command.help.admin": "muestra todo los comandos relacionados con administración.",
+
+  "text.goml.position": "Posición: %s",
+  "text.goml.radius": "Radio: %s",
+  "text.goml.height": "Altura: %s",
+  "text.goml.owners": "Dueños: %s",
+  "text.goml.trusted": "Miembros: %s",
+  "text.goml.your_claims": "Tus protecciones",
+  "text.goml.someones_claims": "Protecciones de %s",
+  "text.goml.owner": "Dueño",
+  "text.goml.apply": "Aplicar cambios",
+
+  "text.goml.admin_mode.enabled": "Se activó el Modo Admin! Ahora puedes modificar las protecciones de otros jugadores!",
+  "text.goml.admin_mode.disabled": "Se desactivó el Modo Admin! Ya no puedes modificar las protecciones de otros jugadores!",
+
+  "text.goml.changed_greeting": "El saludo de bienvenida de tu protección ahora es: %s",
+  "text.goml.disabled_augment": "Este objeto se encuentra desactivado!"
+}

--- a/src/main/resources/data/goml/lang/es_ec.json
+++ b/src/main/resources/data/goml/lang/es_ec.json
@@ -1,0 +1,143 @@
+{
+  "itemGroup.goml.group": "Get Off My Lawn",
+
+  "block.goml.makeshift_claim_anchor": "Protección Improvisada",
+  "block.goml.reinforced_claim_anchor": "Protección Reforzada",
+  "block.goml.glistening_claim_anchor": "Protección Brillante",
+  "block.goml.crystal_claim_anchor": "Protección Cristalina",
+  "block.goml.emeradic_claim_anchor": "Protección Esmeraldina",
+  "block.goml.withered_claim_anchor": "Protección Marchita",
+  "block.goml.admin_claim_anchor": "Protección de Administrador",
+
+  "block.goml.anchor_augment": "Mejora de Protección: %s",
+
+  "block.goml.ender_binding": "Prisión del End",
+  "block.goml.ender_binding.description.1": "Endermans no podrán teletransportarse y",
+  "block.goml.ender_binding.description.2": "colocar bloques dentro de la protección.",
+
+  "block.goml.lake_spirit_grace": "Gracia del Espíritu del Lago",
+  "block.goml.lake_spirit_grace.description.1": "Todos los jugadores dentro de la protección reciben",
+  "block.goml.lake_spirit_grace.description.2": "los efectos de Respiración Acuática y Gracia del Delfín.",
+
+  "block.goml.angelic_aura": "Aura Angelical",
+  "block.goml.angelic_aura.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.angelic_aura.description.2": "reciben el efecto de Regeneración.",
+
+  "block.goml.heaven_wings": "Alas del Cielo",
+  "block.goml.heaven_wings.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.heaven_wings.description.2": "reciben la habilidad de volar.",
+
+  "block.goml.village_core": "Núcleo de Aldea",
+  "block.goml.village_core.description.1": "Los aldeanos dentro de la protección",
+  "block.goml.village_core.description.2": "son protegidos del daño por criaturas hostiles.",
+
+  "block.goml.withering_seal": "Sello Marchito",
+  "block.goml.withering_seal.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.withering_seal.description.2": "son protegidos del efecto de descomposición (wither).",
+
+  "block.goml.chaos_zone": "Zona Caótica",
+  "block.goml.chaos_zone.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.chaos_zone.description.2": "reciben el efecto de Fuerza.",
+
+  "block.goml.defenders_right": "Derecho del Defensor",
+  "block.goml.defenders_right.description.1": "Todos las mascotas dentro de la protección",
+  "block.goml.defenders_right.description.2": "infligen daño extra a sus enemigos.",
+
+  "block.goml.greeter": "Saludador",
+  "block.goml.greeter.description.1": "Envía un mensaje de bienvenida a los jugadores",
+  "block.goml.greeter.description.2": "cuando entran en la protección",
+
+  "block.goml.pvp_arena": "Arena PvP",
+  "block.goml.pvp_arena.description.1": "Activa o desactiva el daño entre jugadores",
+  "block.goml.pvp_arena.description.2": "dentro de la protección",
+
+  "block.goml.explosion_controller": "Control de Explosiones",
+  "block.goml.explosion_controller.description.1": "Activa o desactiva el daño causado por explosiones",
+  "block.goml.explosion_controller.description.2": "naturales (que no son causadas por jugadores).",
+
+  "item.goml.goggles": "Gafas Reveladoras (de Protección)",
+  "item.goml.reinforced_upgrade_kit": "Kit de Mejora Reforzada",
+  "item.goml.glistening_upgrade_kit": "Kit de Mejora Brillante",
+  "item.goml.crystal_upgrade_kit": "Kit de Mejora Cristalina",
+  "item.goml.emeradic_upgrade_kit": "Kit de Mejora Esmeraldina",
+  "item.goml.withered_upgrade_kit": "Kit de Mejora Marchita",
+
+  "text.goml.gui.input_greeting.title": "Saludo de Bienvenida",
+  "text.goml.gui.input_greeting.set": "Guardar cambios",
+  "text.goml.gui.input_greeting.close": "Cancelar cambios",
+  "text.goml.gui.next_page": "Página Siguiente",
+  "text.goml.gui.previous_page": "Página Anterior",
+  "text.goml.gui.close": "Cerrar",
+  "text.goml.gui.back": "Atrás",
+  "text.goml.gui.player_list.title": "Miembros",
+  "text.goml.gui.player_list.add_player": "Añadir Miembro",
+  "text.goml.gui.click_to_remove": "Clic para quitar al miembro de la protección",
+  "text.goml.gui.player_add_gui.title": "Añadir miembro a la protección",
+  "text.goml.gui.claim.title": "Protección",
+  "text.goml.gui.claim.about": "Información...",
+  "text.goml.gui.claim.players": "Miembros...",
+  "text.goml.gui.claim.augments": "Mejoras...",
+  "text.goml.gui.click_to_modify": "Clic para modificar la configuración...",
+  "text.goml.gui.admin_settings": "Modificar Protección de Admin...",
+  "text.goml.gui.augment_list.title": "Mejoras de Protección",
+  "text.goml.gui.admin_settings.title": "Modificar Protección de Admin",
+
+  "text.goml.mode.everyone": "Todos",
+  "text.goml.mode.trusted": "Sólo Miembros",
+  "text.goml.mode.untrusted": "Sólo No Miembros",
+  "text.goml.mode.disabled": "Desactivado",
+  "text.goml.mode.enabled": "Activado",
+  "text.goml.mode_toggle": "Modo: %s",
+  "text.goml.mode_toggle.help": "Clic para cambiar el modo actual",
+  "text.goml.explosion_control_toggle": "Prevenir Explosiones: %s",
+
+  "text.goml.augment": "Mejora: %s",
+
+  "text.goml.command.no_claims": "No te encuentras en ninguna protección!",
+  "text.goml.command.already_added": "El jugador %s ya es miembro de la protección!",
+  "text.goml.command.number_in": "Cantidad de protecciones en %s: %s",
+  "text.goml.command.number_all": "Cantidad de protecciones en todos los mundos: %s",
+  "text.goml.command.owner_added": "%s ha sido añadido como dueño de esta protección.",
+  "text.goml.command.owner_removed": "%s ha sido removido como dueño de esta protección.",
+  "text.goml.command.trusted": "%s ha sido añadido como miembro de esta protección.",
+  "text.goml.command.untrusted": "%s ha sido removido como miembro de esta protección",
+  "text.goml.command.add_self": "Ya tienes permisos en la protección!",
+  "text.goml.command.remove_self": "No puedes removerte a ti mismo de esta protección!",
+  "text.goml.command.removed_claim": "La protección en %s con origen %s ha sido removida.",
+
+  "text.goml.block_protected": "Este bloque se encuentra protegido!",
+  "text.goml.entity_protected": "Esta entidad se encuentra protegida!",
+  "text.goml.area_protected": "Esta área se encuentra protegida!",
+
+  "text.goml.cant_place_claim.max_count_reached": "No puedes tener más protecciones! Ya tienes %s protecciones!",
+  "text.goml.cant_place_claim.blacklisted_area": "No puedes proteger en el mundo %s en %s! Esta área se encuentra en la lista negra!",
+  "text.goml.cant_place_claim.collides_with": "No puedes proteger aquí porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+  "text.goml.cant_place_claim.admin_only": "No puedes crear esa protección, primero debes activar el Modo Admin!",
+
+  "text.goml.cant_upgrade_claim.collides_with": "No puedes mejorar esta protección porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+
+  "text.goml.command.help.help": "muestra este mensaje.",
+  "text.goml.command.help.info": "muestra información acerca de la protección en tu posición actual.",
+  "text.goml.command.help.addowner": "añade un dueño a la protección en tu posición actual.",
+  "text.goml.command.help.trust": "añade un miembro a la protección en tu posición actual.",
+  "text.goml.command.help.untrust": "remueve un miembro de la protección en tu posición actual.",
+  "text.goml.command.help.list": "muestra todas las protecciones en las que tienes permisos.",
+  "text.goml.command.help.gui": "muestra el menú de la protección en tu posición actual.",
+  "text.goml.command.help.admin": "muestra todo los comandos relacionados con administración.",
+
+  "text.goml.position": "Posición: %s",
+  "text.goml.radius": "Radio: %s",
+  "text.goml.height": "Altura: %s",
+  "text.goml.owners": "Dueños: %s",
+  "text.goml.trusted": "Miembros: %s",
+  "text.goml.your_claims": "Tus protecciones",
+  "text.goml.someones_claims": "Protecciones de %s",
+  "text.goml.owner": "Dueño",
+  "text.goml.apply": "Aplicar cambios",
+
+  "text.goml.admin_mode.enabled": "Se activó el Modo Admin! Ahora puedes modificar las protecciones de otros jugadores!",
+  "text.goml.admin_mode.disabled": "Se desactivó el Modo Admin! Ya no puedes modificar las protecciones de otros jugadores!",
+
+  "text.goml.changed_greeting": "El saludo de bienvenida de tu protección ahora es: %s",
+  "text.goml.disabled_augment": "Este objeto se encuentra desactivado!"
+}

--- a/src/main/resources/data/goml/lang/es_es.json
+++ b/src/main/resources/data/goml/lang/es_es.json
@@ -1,0 +1,143 @@
+{
+  "itemGroup.goml.group": "Get Off My Lawn",
+
+  "block.goml.makeshift_claim_anchor": "Protección Improvisada",
+  "block.goml.reinforced_claim_anchor": "Protección Reforzada",
+  "block.goml.glistening_claim_anchor": "Protección Brillante",
+  "block.goml.crystal_claim_anchor": "Protección Cristalina",
+  "block.goml.emeradic_claim_anchor": "Protección Esmeraldina",
+  "block.goml.withered_claim_anchor": "Protección Marchita",
+  "block.goml.admin_claim_anchor": "Protección de Administrador",
+
+  "block.goml.anchor_augment": "Mejora de Protección: %s",
+
+  "block.goml.ender_binding": "Prisión del End",
+  "block.goml.ender_binding.description.1": "Endermans no podrán teletransportarse y",
+  "block.goml.ender_binding.description.2": "colocar bloques dentro de la protección.",
+
+  "block.goml.lake_spirit_grace": "Gracia del Espíritu del Lago",
+  "block.goml.lake_spirit_grace.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.lake_spirit_grace.description.2": "reciben los efectos de Apnea y Gracia del Delfín.",
+
+  "block.goml.angelic_aura": "Aura Angelical",
+  "block.goml.angelic_aura.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.angelic_aura.description.2": "reciben el efecto de Regeneración.",
+
+  "block.goml.heaven_wings": "Alas del Cielo",
+  "block.goml.heaven_wings.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.heaven_wings.description.2": "reciben la habilidad de volar.",
+
+  "block.goml.village_core": "Núcleo de Aldea",
+  "block.goml.village_core.description.1": "Los aldeanos dentro de la protección",
+  "block.goml.village_core.description.2": "son protegidos del daño por criaturas hostiles.",
+
+  "block.goml.withering_seal": "Sello Marchito",
+  "block.goml.withering_seal.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.withering_seal.description.2": "son protegidos del efecto de descomposición (wither).",
+
+  "block.goml.chaos_zone": "Zona Caótica",
+  "block.goml.chaos_zone.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.chaos_zone.description.2": "reciben el efecto de Fuerza.",
+
+  "block.goml.defenders_right": "Derecho del Defensor",
+  "block.goml.defenders_right.description.1": "Todos las mascotas dentro de la protección",
+  "block.goml.defenders_right.description.2": "infligen daño extra a sus enemigos.",
+
+  "block.goml.greeter": "Saludador",
+  "block.goml.greeter.description.1": "Envía un mensaje de bienvenida a los jugadores",
+  "block.goml.greeter.description.2": "cuando entran en la protección",
+
+  "block.goml.pvp_arena": "Arena PvP",
+  "block.goml.pvp_arena.description.1": "Activa o desactiva el daño entre jugadores",
+  "block.goml.pvp_arena.description.2": "dentro de la protección",
+
+  "block.goml.explosion_controller": "Control de Explosiones",
+  "block.goml.explosion_controller.description.1": "Activa o desactiva el daño causado por explosiones",
+  "block.goml.explosion_controller.description.2": "naturales (que no son causadas por jugadores).",
+
+  "item.goml.goggles": "Gafas Reveladoras (de Protección)",
+  "item.goml.reinforced_upgrade_kit": "Kit de Mejora Reforzada",
+  "item.goml.glistening_upgrade_kit": "Kit de Mejora Brillante",
+  "item.goml.crystal_upgrade_kit": "Kit de Mejora Cristalina",
+  "item.goml.emeradic_upgrade_kit": "Kit de Mejora Esmeraldina",
+  "item.goml.withered_upgrade_kit": "Kit de Mejora Marchita",
+
+  "text.goml.gui.input_greeting.title": "Saludo de Bienvenida",
+  "text.goml.gui.input_greeting.set": "Guardar cambios",
+  "text.goml.gui.input_greeting.close": "Cancelar cambios",
+  "text.goml.gui.next_page": "Página Siguiente",
+  "text.goml.gui.previous_page": "Página Anterior",
+  "text.goml.gui.close": "Cerrar",
+  "text.goml.gui.back": "Atrás",
+  "text.goml.gui.player_list.title": "Miembros",
+  "text.goml.gui.player_list.add_player": "Añadir Miembro",
+  "text.goml.gui.click_to_remove": "Clic para quitar al miembro de la protección",
+  "text.goml.gui.player_add_gui.title": "Añadir miembro a la protección",
+  "text.goml.gui.claim.title": "Protección",
+  "text.goml.gui.claim.about": "Información...",
+  "text.goml.gui.claim.players": "Miembros...",
+  "text.goml.gui.claim.augments": "Mejoras...",
+  "text.goml.gui.click_to_modify": "Clic para modificar la configuración...",
+  "text.goml.gui.admin_settings": "Modificar Protección de Admin...",
+  "text.goml.gui.augment_list.title": "Mejoras de Protección",
+  "text.goml.gui.admin_settings.title": "Modificar Protección de Admin",
+
+  "text.goml.mode.everyone": "Todos",
+  "text.goml.mode.trusted": "Sólo Miembros",
+  "text.goml.mode.untrusted": "Sólo No Miembros",
+  "text.goml.mode.disabled": "Desactivado",
+  "text.goml.mode.enabled": "Activado",
+  "text.goml.mode_toggle": "Modo: %s",
+  "text.goml.mode_toggle.help": "Clic para cambiar el modo actual",
+  "text.goml.explosion_control_toggle": "Prevenir Explosiones: %s",
+
+  "text.goml.augment": "Mejora: %s",
+
+  "text.goml.command.no_claims": "No te encuentras en ninguna protección!",
+  "text.goml.command.already_added": "El jugador %s ya es miembro de la protección!",
+  "text.goml.command.number_in": "Cantidad de protecciones en %s: %s",
+  "text.goml.command.number_all": "Cantidad de protecciones en todos los mundos: %s",
+  "text.goml.command.owner_added": "%s ha sido añadido como dueño de esta protección.",
+  "text.goml.command.owner_removed": "%s ha sido removido como dueño de esta protección.",
+  "text.goml.command.trusted": "%s ha sido añadido como miembro de esta protección.",
+  "text.goml.command.untrusted": "%s ha sido removido como miembro de esta protección",
+  "text.goml.command.add_self": "Ya tienes permisos en la protección!",
+  "text.goml.command.remove_self": "No puedes removerte a ti mismo de esta protección!",
+  "text.goml.command.removed_claim": "La protección en %s con origen %s ha sido removida.",
+
+  "text.goml.block_protected": "Este bloque se encuentra protegido!",
+  "text.goml.entity_protected": "Esta entidad se encuentra protegida!",
+  "text.goml.area_protected": "Esta área se encuentra protegida!",
+
+  "text.goml.cant_place_claim.max_count_reached": "No puedes tener más protecciones! Ya tienes %s protecciones!",
+  "text.goml.cant_place_claim.blacklisted_area": "No puedes proteger en el mundo %s en %s! Esta área se encuentra en la lista negra!",
+  "text.goml.cant_place_claim.collides_with": "No puedes proteger aquí porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+  "text.goml.cant_place_claim.admin_only": "No puedes crear esa protección, primero debes activar el Modo Admin!",
+
+  "text.goml.cant_upgrade_claim.collides_with": "No puedes mejorar esta protección porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+
+  "text.goml.command.help.help": "muestra este mensaje.",
+  "text.goml.command.help.info": "muestra información acerca de la protección en tu posición actual.",
+  "text.goml.command.help.addowner": "añade un dueño a la protección en tu posición actual.",
+  "text.goml.command.help.trust": "añade un miembro a la protección en tu posición actual.",
+  "text.goml.command.help.untrust": "remueve un miembro de la protección en tu posición actual.",
+  "text.goml.command.help.list": "muestra todas las protecciones en las que tienes permisos.",
+  "text.goml.command.help.gui": "muestra el menú de la protección en tu posición actual.",
+  "text.goml.command.help.admin": "muestra todo los comandos relacionados con administración.",
+
+  "text.goml.position": "Posición: %s",
+  "text.goml.radius": "Radio: %s",
+  "text.goml.height": "Altura: %s",
+  "text.goml.owners": "Dueños: %s",
+  "text.goml.trusted": "Miembros: %s",
+  "text.goml.your_claims": "Tus protecciones",
+  "text.goml.someones_claims": "Protecciones de %s",
+  "text.goml.owner": "Dueño",
+  "text.goml.apply": "Aplicar cambios",
+
+  "text.goml.admin_mode.enabled": "Se activó el Modo Admin! Ahora puedes modificar las protecciones de otros jugadores!",
+  "text.goml.admin_mode.disabled": "Se desactivó el Modo Admin! Ya no puedes modificar las protecciones de otros jugadores!",
+
+  "text.goml.changed_greeting": "El saludo de bienvenida de tu protección ahora es: %s",
+  "text.goml.disabled_augment": "Este objeto se encuentra desactivado!"
+}

--- a/src/main/resources/data/goml/lang/es_mx.json
+++ b/src/main/resources/data/goml/lang/es_mx.json
@@ -1,0 +1,143 @@
+{
+  "itemGroup.goml.group": "Get Off My Lawn",
+
+  "block.goml.makeshift_claim_anchor": "Protección Improvisada",
+  "block.goml.reinforced_claim_anchor": "Protección Reforzada",
+  "block.goml.glistening_claim_anchor": "Protección Brillante",
+  "block.goml.crystal_claim_anchor": "Protección Cristalina",
+  "block.goml.emeradic_claim_anchor": "Protección Esmeraldina",
+  "block.goml.withered_claim_anchor": "Protección Marchita",
+  "block.goml.admin_claim_anchor": "Protección de Administrador",
+
+  "block.goml.anchor_augment": "Mejora de Protección: %s",
+
+  "block.goml.ender_binding": "Prisión del End",
+  "block.goml.ender_binding.description.1": "Endermans no podrán teletransportarse y",
+  "block.goml.ender_binding.description.2": "colocar bloques dentro de la protección.",
+
+  "block.goml.lake_spirit_grace": "Gracia del Espíritu del Lago",
+  "block.goml.lake_spirit_grace.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.lake_spirit_grace.description.2": "reciben los efectos de Respiración y Gracia Delfina.",
+
+  "block.goml.angelic_aura": "Aura Angelical",
+  "block.goml.angelic_aura.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.angelic_aura.description.2": "reciben el efecto de Regeneración.",
+
+  "block.goml.heaven_wings": "Alas del Cielo",
+  "block.goml.heaven_wings.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.heaven_wings.description.2": "reciben la habilidad de volar.",
+
+  "block.goml.village_core": "Núcleo de Aldea",
+  "block.goml.village_core.description.1": "Los aldeanos dentro de la protección",
+  "block.goml.village_core.description.2": "son protegidos del daño por criaturas hostiles.",
+
+  "block.goml.withering_seal": "Sello Marchito",
+  "block.goml.withering_seal.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.withering_seal.description.2": "son protegidos del efecto de descomposición (wither).",
+
+  "block.goml.chaos_zone": "Zona Caótica",
+  "block.goml.chaos_zone.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.chaos_zone.description.2": "reciben el efecto de Fuerza.",
+
+  "block.goml.defenders_right": "Derecho del Defensor",
+  "block.goml.defenders_right.description.1": "Todos las mascotas dentro de la protección",
+  "block.goml.defenders_right.description.2": "infligen daño extra a sus enemigos.",
+
+  "block.goml.greeter": "Saludador",
+  "block.goml.greeter.description.1": "Envía un mensaje de bienvenida a los jugadores",
+  "block.goml.greeter.description.2": "cuando entran en la protección",
+
+  "block.goml.pvp_arena": "Arena PvP",
+  "block.goml.pvp_arena.description.1": "Activa o desactiva el daño entre jugadores",
+  "block.goml.pvp_arena.description.2": "dentro de la protección",
+
+  "block.goml.explosion_controller": "Control de Explosiones",
+  "block.goml.explosion_controller.description.1": "Activa o desactiva el daño causado por explosiones",
+  "block.goml.explosion_controller.description.2": "naturales (que no son causadas por jugadores).",
+
+  "item.goml.goggles": "Gafas Reveladoras (de Protección)",
+  "item.goml.reinforced_upgrade_kit": "Kit de Mejora Reforzada",
+  "item.goml.glistening_upgrade_kit": "Kit de Mejora Brillante",
+  "item.goml.crystal_upgrade_kit": "Kit de Mejora Cristalina",
+  "item.goml.emeradic_upgrade_kit": "Kit de Mejora Esmeraldina",
+  "item.goml.withered_upgrade_kit": "Kit de Mejora Marchita",
+
+  "text.goml.gui.input_greeting.title": "Saludo de Bienvenida",
+  "text.goml.gui.input_greeting.set": "Guardar cambios",
+  "text.goml.gui.input_greeting.close": "Cancelar cambios",
+  "text.goml.gui.next_page": "Página Siguiente",
+  "text.goml.gui.previous_page": "Página Anterior",
+  "text.goml.gui.close": "Cerrar",
+  "text.goml.gui.back": "Atrás",
+  "text.goml.gui.player_list.title": "Miembros",
+  "text.goml.gui.player_list.add_player": "Añadir Miembro",
+  "text.goml.gui.click_to_remove": "Clic para quitar al miembro de la protección",
+  "text.goml.gui.player_add_gui.title": "Añadir miembro a la protección",
+  "text.goml.gui.claim.title": "Protección",
+  "text.goml.gui.claim.about": "Información...",
+  "text.goml.gui.claim.players": "Miembros...",
+  "text.goml.gui.claim.augments": "Mejoras...",
+  "text.goml.gui.click_to_modify": "Clic para modificar la configuración...",
+  "text.goml.gui.admin_settings": "Modificar Protección de Admin...",
+  "text.goml.gui.augment_list.title": "Mejoras de Protección",
+  "text.goml.gui.admin_settings.title": "Modificar Protección de Admin",
+
+  "text.goml.mode.everyone": "Todos",
+  "text.goml.mode.trusted": "Sólo Miembros",
+  "text.goml.mode.untrusted": "Sólo No Miembros",
+  "text.goml.mode.disabled": "Desactivado",
+  "text.goml.mode.enabled": "Activado",
+  "text.goml.mode_toggle": "Modo: %s",
+  "text.goml.mode_toggle.help": "Clic para cambiar el modo actual",
+  "text.goml.explosion_control_toggle": "Prevenir Explosiones: %s",
+
+  "text.goml.augment": "Mejora: %s",
+
+  "text.goml.command.no_claims": "No te encuentras en ninguna protección!",
+  "text.goml.command.already_added": "El jugador %s ya es miembro de la protección!",
+  "text.goml.command.number_in": "Cantidad de protecciones en %s: %s",
+  "text.goml.command.number_all": "Cantidad de protecciones en todos los mundos: %s",
+  "text.goml.command.owner_added": "%s ha sido añadido como dueño de esta protección.",
+  "text.goml.command.owner_removed": "%s ha sido removido como dueño de esta protección.",
+  "text.goml.command.trusted": "%s ha sido añadido como miembro de esta protección.",
+  "text.goml.command.untrusted": "%s ha sido removido como miembro de esta protección",
+  "text.goml.command.add_self": "Ya tienes permisos en la protección!",
+  "text.goml.command.remove_self": "No puedes removerte a ti mismo de esta protección!",
+  "text.goml.command.removed_claim": "La protección en %s con origen %s ha sido removida.",
+
+  "text.goml.block_protected": "Este bloque se encuentra protegido!",
+  "text.goml.entity_protected": "Esta entidad se encuentra protegida!",
+  "text.goml.area_protected": "Esta área se encuentra protegida!",
+
+  "text.goml.cant_place_claim.max_count_reached": "No puedes tener más protecciones! Ya tienes %s protecciones!",
+  "text.goml.cant_place_claim.blacklisted_area": "No puedes proteger en el mundo %s en %s! Esta área se encuentra en la lista negra!",
+  "text.goml.cant_place_claim.collides_with": "No puedes proteger aquí porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+  "text.goml.cant_place_claim.admin_only": "No puedes crear esa protección, primero debes activar el Modo Admin!",
+
+  "text.goml.cant_upgrade_claim.collides_with": "No puedes mejorar esta protección porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+
+  "text.goml.command.help.help": "muestra este mensaje.",
+  "text.goml.command.help.info": "muestra información acerca de la protección en tu posición actual.",
+  "text.goml.command.help.addowner": "añade un dueño a la protección en tu posición actual.",
+  "text.goml.command.help.trust": "añade un miembro a la protección en tu posición actual.",
+  "text.goml.command.help.untrust": "remueve un miembro de la protección en tu posición actual.",
+  "text.goml.command.help.list": "muestra todas las protecciones en las que tienes permisos.",
+  "text.goml.command.help.gui": "muestra el menú de la protección en tu posición actual.",
+  "text.goml.command.help.admin": "muestra todo los comandos relacionados con administración.",
+
+  "text.goml.position": "Posición: %s",
+  "text.goml.radius": "Radio: %s",
+  "text.goml.height": "Altura: %s",
+  "text.goml.owners": "Dueños: %s",
+  "text.goml.trusted": "Miembros: %s",
+  "text.goml.your_claims": "Tus protecciones",
+  "text.goml.someones_claims": "Protecciones de %s",
+  "text.goml.owner": "Dueño",
+  "text.goml.apply": "Aplicar cambios",
+
+  "text.goml.admin_mode.enabled": "Se activó el Modo Admin! Ahora puedes modificar las protecciones de otros jugadores!",
+  "text.goml.admin_mode.disabled": "Se desactivó el Modo Admin! Ya no puedes modificar las protecciones de otros jugadores!",
+
+  "text.goml.changed_greeting": "El saludo de bienvenida de tu protección ahora es: %s",
+  "text.goml.disabled_augment": "Este objeto se encuentra desactivado!"
+}

--- a/src/main/resources/data/goml/lang/es_uy.json
+++ b/src/main/resources/data/goml/lang/es_uy.json
@@ -1,0 +1,143 @@
+{
+  "itemGroup.goml.group": "Get Off My Lawn",
+
+  "block.goml.makeshift_claim_anchor": "Protección Improvisada",
+  "block.goml.reinforced_claim_anchor": "Protección Reforzada",
+  "block.goml.glistening_claim_anchor": "Protección Brillante",
+  "block.goml.crystal_claim_anchor": "Protección Cristalina",
+  "block.goml.emeradic_claim_anchor": "Protección Esmeraldina",
+  "block.goml.withered_claim_anchor": "Protección Marchita",
+  "block.goml.admin_claim_anchor": "Protección de Administrador",
+
+  "block.goml.anchor_augment": "Mejora de Protección: %s",
+
+  "block.goml.ender_binding": "Prisión del End",
+  "block.goml.ender_binding.description.1": "Endermans no podrán teletransportarse y",
+  "block.goml.ender_binding.description.2": "colocar bloques dentro de la protección.",
+
+  "block.goml.lake_spirit_grace": "Gracia del Espíritu del Lago",
+  "block.goml.lake_spirit_grace.description.1": "Todos los jugadores dentro de la protección reciben",
+  "block.goml.lake_spirit_grace.description.2": "los efectos de Respiración Acuática y Gracia Delfina.",
+
+  "block.goml.angelic_aura": "Aura Angelical",
+  "block.goml.angelic_aura.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.angelic_aura.description.2": "reciben el efecto de Regeneración.",
+
+  "block.goml.heaven_wings": "Alas del Cielo",
+  "block.goml.heaven_wings.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.heaven_wings.description.2": "reciben la habilidad de volar.",
+
+  "block.goml.village_core": "Núcleo de Aldea",
+  "block.goml.village_core.description.1": "Los aldeanos dentro de la protección",
+  "block.goml.village_core.description.2": "son protegidos del daño por criaturas hostiles.",
+
+  "block.goml.withering_seal": "Sello Marchito",
+  "block.goml.withering_seal.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.withering_seal.description.2": "son protegidos del efecto de wither.",
+
+  "block.goml.chaos_zone": "Zona Caótica",
+  "block.goml.chaos_zone.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.chaos_zone.description.2": "reciben el efecto de Fuerza.",
+
+  "block.goml.defenders_right": "Derecho del Defensor",
+  "block.goml.defenders_right.description.1": "Todos las mascotas dentro de la protección",
+  "block.goml.defenders_right.description.2": "infligen daño extra a sus enemigos.",
+
+  "block.goml.greeter": "Saludador",
+  "block.goml.greeter.description.1": "Envía un mensaje de bienvenida a los jugadores",
+  "block.goml.greeter.description.2": "cuando entran en la protección",
+
+  "block.goml.pvp_arena": "Arena PvP",
+  "block.goml.pvp_arena.description.1": "Activa o desactiva el daño entre jugadores",
+  "block.goml.pvp_arena.description.2": "dentro de la protección",
+
+  "block.goml.explosion_controller": "Control de Explosiones",
+  "block.goml.explosion_controller.description.1": "Activa o desactiva el daño causado por explosiones",
+  "block.goml.explosion_controller.description.2": "naturales (que no son causadas por jugadores).",
+
+  "item.goml.goggles": "Gafas Reveladoras (de Protección)",
+  "item.goml.reinforced_upgrade_kit": "Kit de Mejora Reforzada",
+  "item.goml.glistening_upgrade_kit": "Kit de Mejora Brillante",
+  "item.goml.crystal_upgrade_kit": "Kit de Mejora Cristalina",
+  "item.goml.emeradic_upgrade_kit": "Kit de Mejora Esmeraldina",
+  "item.goml.withered_upgrade_kit": "Kit de Mejora Marchita",
+
+  "text.goml.gui.input_greeting.title": "Saludo de Bienvenida",
+  "text.goml.gui.input_greeting.set": "Guardar cambios",
+  "text.goml.gui.input_greeting.close": "Cancelar cambios",
+  "text.goml.gui.next_page": "Página Siguiente",
+  "text.goml.gui.previous_page": "Página Anterior",
+  "text.goml.gui.close": "Cerrar",
+  "text.goml.gui.back": "Atrás",
+  "text.goml.gui.player_list.title": "Miembros",
+  "text.goml.gui.player_list.add_player": "Añadir Miembro",
+  "text.goml.gui.click_to_remove": "Clic para quitar al miembro de la protección",
+  "text.goml.gui.player_add_gui.title": "Añadir miembro a la protección",
+  "text.goml.gui.claim.title": "Protección",
+  "text.goml.gui.claim.about": "Información...",
+  "text.goml.gui.claim.players": "Miembros...",
+  "text.goml.gui.claim.augments": "Mejoras...",
+  "text.goml.gui.click_to_modify": "Clic para modificar la configuración...",
+  "text.goml.gui.admin_settings": "Modificar Protección de Admin...",
+  "text.goml.gui.augment_list.title": "Mejoras de Protección",
+  "text.goml.gui.admin_settings.title": "Modificar Protección de Admin",
+
+  "text.goml.mode.everyone": "Todos",
+  "text.goml.mode.trusted": "Sólo Miembros",
+  "text.goml.mode.untrusted": "Sólo No Miembros",
+  "text.goml.mode.disabled": "Desactivado",
+  "text.goml.mode.enabled": "Activado",
+  "text.goml.mode_toggle": "Modo: %s",
+  "text.goml.mode_toggle.help": "Clic para cambiar el modo actual",
+  "text.goml.explosion_control_toggle": "Prevenir Explosiones: %s",
+
+  "text.goml.augment": "Mejora: %s",
+
+  "text.goml.command.no_claims": "No te encuentras en ninguna protección!",
+  "text.goml.command.already_added": "El jugador %s ya es miembro de la protección!",
+  "text.goml.command.number_in": "Cantidad de protecciones en %s: %s",
+  "text.goml.command.number_all": "Cantidad de protecciones en todos los mundos: %s",
+  "text.goml.command.owner_added": "%s ha sido añadido como dueño de esta protección.",
+  "text.goml.command.owner_removed": "%s ha sido removido como dueño de esta protección.",
+  "text.goml.command.trusted": "%s ha sido añadido como miembro de esta protección.",
+  "text.goml.command.untrusted": "%s ha sido removido como miembro de esta protección",
+  "text.goml.command.add_self": "Ya tienes permisos en la protección!",
+  "text.goml.command.remove_self": "No puedes removerte a ti mismo de esta protección!",
+  "text.goml.command.removed_claim": "La protección en %s con origen %s ha sido removida.",
+
+  "text.goml.block_protected": "Este bloque se encuentra protegido!",
+  "text.goml.entity_protected": "Esta entidad se encuentra protegida!",
+  "text.goml.area_protected": "Esta área se encuentra protegida!",
+
+  "text.goml.cant_place_claim.max_count_reached": "No puedes tener más protecciones! Ya tienes %s protecciones!",
+  "text.goml.cant_place_claim.blacklisted_area": "No puedes proteger en el mundo %s en %s! Esta área se encuentra en la lista negra!",
+  "text.goml.cant_place_claim.collides_with": "No puedes proteger aquí porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+  "text.goml.cant_place_claim.admin_only": "No puedes crear esa protección, primero debes activar el Modo Admin!",
+
+  "text.goml.cant_upgrade_claim.collides_with": "No puedes mejorar esta protección porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+
+  "text.goml.command.help.help": "muestra este mensaje.",
+  "text.goml.command.help.info": "muestra información acerca de la protección en tu posición actual.",
+  "text.goml.command.help.addowner": "añade un dueño a la protección en tu posición actual.",
+  "text.goml.command.help.trust": "añade un miembro a la protección en tu posición actual.",
+  "text.goml.command.help.untrust": "remueve un miembro de la protección en tu posición actual.",
+  "text.goml.command.help.list": "muestra todas las protecciones en las que tienes permisos.",
+  "text.goml.command.help.gui": "muestra el menú de la protección en tu posición actual.",
+  "text.goml.command.help.admin": "muestra todo los comandos relacionados con administración.",
+
+  "text.goml.position": "Posición: %s",
+  "text.goml.radius": "Radio: %s",
+  "text.goml.height": "Altura: %s",
+  "text.goml.owners": "Dueños: %s",
+  "text.goml.trusted": "Miembros: %s",
+  "text.goml.your_claims": "Tus protecciones",
+  "text.goml.someones_claims": "Protecciones de %s",
+  "text.goml.owner": "Dueño",
+  "text.goml.apply": "Aplicar cambios",
+
+  "text.goml.admin_mode.enabled": "Se activó el Modo Admin! Ahora puedes modificar las protecciones de otros jugadores!",
+  "text.goml.admin_mode.disabled": "Se desactivó el Modo Admin! Ya no puedes modificar las protecciones de otros jugadores!",
+
+  "text.goml.changed_greeting": "El saludo de bienvenida de tu protección ahora es: %s",
+  "text.goml.disabled_augment": "Este objeto se encuentra desactivado!"
+}

--- a/src/main/resources/data/goml/lang/es_ve.json
+++ b/src/main/resources/data/goml/lang/es_ve.json
@@ -1,0 +1,143 @@
+{
+  "itemGroup.goml.group": "Get Off My Lawn",
+
+  "block.goml.makeshift_claim_anchor": "Protección Improvisada",
+  "block.goml.reinforced_claim_anchor": "Protección Reforzada",
+  "block.goml.glistening_claim_anchor": "Protección Brillante",
+  "block.goml.crystal_claim_anchor": "Protección Cristalina",
+  "block.goml.emeradic_claim_anchor": "Protección Esmeraldina",
+  "block.goml.withered_claim_anchor": "Protección Marchita",
+  "block.goml.admin_claim_anchor": "Protección de Administrador",
+
+  "block.goml.anchor_augment": "Mejora de Protección: %s",
+
+  "block.goml.ender_binding": "Prisión del End",
+  "block.goml.ender_binding.description.1": "Endermans no podrán teletransportarse y",
+  "block.goml.ender_binding.description.2": "colocar bloques dentro de la protección.",
+
+  "block.goml.lake_spirit_grace": "Gracia del Espíritu del Lago",
+  "block.goml.lake_spirit_grace.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.lake_spirit_grace.description.2": "reciben los efectos de Respiración y Gracia Delfina.",
+
+  "block.goml.angelic_aura": "Aura Angelical",
+  "block.goml.angelic_aura.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.angelic_aura.description.2": "reciben el efecto de Regeneración.",
+
+  "block.goml.heaven_wings": "Alas del Cielo",
+  "block.goml.heaven_wings.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.heaven_wings.description.2": "reciben la habilidad de volar.",
+
+  "block.goml.village_core": "Núcleo de Aldea",
+  "block.goml.village_core.description.1": "Los aldeanos dentro de la protección",
+  "block.goml.village_core.description.2": "son protegidos del daño por criaturas hostiles.",
+
+  "block.goml.withering_seal": "Sello Marchito",
+  "block.goml.withering_seal.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.withering_seal.description.2": "son protegidos del efecto de descomposición (wither).",
+
+  "block.goml.chaos_zone": "Zona Caótica",
+  "block.goml.chaos_zone.description.1": "Todos los jugadores dentro de la protección",
+  "block.goml.chaos_zone.description.2": "reciben el efecto de Fuerza.",
+
+  "block.goml.defenders_right": "Derecho del Defensor",
+  "block.goml.defenders_right.description.1": "Todos las mascotas dentro de la protección",
+  "block.goml.defenders_right.description.2": "infligen daño extra a sus enemigos.",
+
+  "block.goml.greeter": "Saludador",
+  "block.goml.greeter.description.1": "Envía un mensaje de bienvenida a los jugadores",
+  "block.goml.greeter.description.2": "cuando entran en la protección",
+
+  "block.goml.pvp_arena": "Arena PvP",
+  "block.goml.pvp_arena.description.1": "Activa o desactiva el daño entre jugadores",
+  "block.goml.pvp_arena.description.2": "dentro de la protección",
+
+  "block.goml.explosion_controller": "Control de Explosiones",
+  "block.goml.explosion_controller.description.1": "Activa o desactiva el daño causado por explosiones",
+  "block.goml.explosion_controller.description.2": "naturales (que no son causadas por jugadores).",
+
+  "item.goml.goggles": "Gafas Reveladoras (de Protección)",
+  "item.goml.reinforced_upgrade_kit": "Kit de Mejora Reforzada",
+  "item.goml.glistening_upgrade_kit": "Kit de Mejora Brillante",
+  "item.goml.crystal_upgrade_kit": "Kit de Mejora Cristalina",
+  "item.goml.emeradic_upgrade_kit": "Kit de Mejora Esmeraldina",
+  "item.goml.withered_upgrade_kit": "Kit de Mejora Marchita",
+
+  "text.goml.gui.input_greeting.title": "Saludo de Bienvenida",
+  "text.goml.gui.input_greeting.set": "Guardar cambios",
+  "text.goml.gui.input_greeting.close": "Cancelar cambios",
+  "text.goml.gui.next_page": "Página Siguiente",
+  "text.goml.gui.previous_page": "Página Anterior",
+  "text.goml.gui.close": "Cerrar",
+  "text.goml.gui.back": "Atrás",
+  "text.goml.gui.player_list.title": "Miembros",
+  "text.goml.gui.player_list.add_player": "Añadir Miembro",
+  "text.goml.gui.click_to_remove": "Clic para quitar al miembro de la protección",
+  "text.goml.gui.player_add_gui.title": "Añadir miembro a la protección",
+  "text.goml.gui.claim.title": "Protección",
+  "text.goml.gui.claim.about": "Información...",
+  "text.goml.gui.claim.players": "Miembros...",
+  "text.goml.gui.claim.augments": "Mejoras...",
+  "text.goml.gui.click_to_modify": "Clic para modificar la configuración...",
+  "text.goml.gui.admin_settings": "Modificar Protección de Admin...",
+  "text.goml.gui.augment_list.title": "Mejoras de Protección",
+  "text.goml.gui.admin_settings.title": "Modificar Protección de Admin",
+
+  "text.goml.mode.everyone": "Todos",
+  "text.goml.mode.trusted": "Sólo Miembros",
+  "text.goml.mode.untrusted": "Sólo No Miembros",
+  "text.goml.mode.disabled": "Desactivado",
+  "text.goml.mode.enabled": "Activado",
+  "text.goml.mode_toggle": "Modo: %s",
+  "text.goml.mode_toggle.help": "Clic para cambiar el modo actual",
+  "text.goml.explosion_control_toggle": "Prevenir Explosiones: %s",
+
+  "text.goml.augment": "Mejora: %s",
+
+  "text.goml.command.no_claims": "No te encuentras en ninguna protección!",
+  "text.goml.command.already_added": "El jugador %s ya es miembro de la protección!",
+  "text.goml.command.number_in": "Cantidad de protecciones en %s: %s",
+  "text.goml.command.number_all": "Cantidad de protecciones en todos los mundos: %s",
+  "text.goml.command.owner_added": "%s ha sido añadido como dueño de esta protección.",
+  "text.goml.command.owner_removed": "%s ha sido removido como dueño de esta protección.",
+  "text.goml.command.trusted": "%s ha sido añadido como miembro de esta protección.",
+  "text.goml.command.untrusted": "%s ha sido removido como miembro de esta protección",
+  "text.goml.command.add_self": "Ya tienes permisos en la protección!",
+  "text.goml.command.remove_self": "No puedes removerte a ti mismo de esta protección!",
+  "text.goml.command.removed_claim": "La protección en %s con origen %s ha sido removida.",
+
+  "text.goml.block_protected": "Este bloque se encuentra protegido!",
+  "text.goml.entity_protected": "Esta entidad se encuentra protegida!",
+  "text.goml.area_protected": "Esta área se encuentra protegida!",
+
+  "text.goml.cant_place_claim.max_count_reached": "No puedes tener más protecciones! Ya tienes %s protecciones!",
+  "text.goml.cant_place_claim.blacklisted_area": "No puedes proteger en el mundo %s en %s! Esta área se encuentra en la lista negra!",
+  "text.goml.cant_place_claim.collides_with": "No puedes proteger aquí porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+  "text.goml.cant_place_claim.admin_only": "No puedes crear esa protección, primero debes activar el Modo Admin!",
+
+  "text.goml.cant_upgrade_claim.collides_with": "No puedes mejorar esta protección porque existe un conflicto con otras protecciones! Protecciones en conflicto: %s",
+
+  "text.goml.command.help.help": "muestra este mensaje.",
+  "text.goml.command.help.info": "muestra información acerca de la protección en tu posición actual.",
+  "text.goml.command.help.addowner": "añade un dueño a la protección en tu posición actual.",
+  "text.goml.command.help.trust": "añade un miembro a la protección en tu posición actual.",
+  "text.goml.command.help.untrust": "remueve un miembro de la protección en tu posición actual.",
+  "text.goml.command.help.list": "muestra todas las protecciones en las que tienes permisos.",
+  "text.goml.command.help.gui": "muestra el menú de la protección en tu posición actual.",
+  "text.goml.command.help.admin": "muestra todo los comandos relacionados con administración.",
+
+  "text.goml.position": "Posición: %s",
+  "text.goml.radius": "Radio: %s",
+  "text.goml.height": "Altura: %s",
+  "text.goml.owners": "Dueños: %s",
+  "text.goml.trusted": "Miembros: %s",
+  "text.goml.your_claims": "Tus protecciones",
+  "text.goml.someones_claims": "Protecciones de %s",
+  "text.goml.owner": "Dueño",
+  "text.goml.apply": "Aplicar cambios",
+
+  "text.goml.admin_mode.enabled": "Se activó el Modo Admin! Ahora puedes modificar las protecciones de otros jugadores!",
+  "text.goml.admin_mode.disabled": "Se desactivó el Modo Admin! Ya no puedes modificar las protecciones de otros jugadores!",
+
+  "text.goml.changed_greeting": "El saludo de bienvenida de tu protección ahora es: %s",
+  "text.goml.disabled_augment": "Este objeto se encuentra desactivado!"
+}


### PR DESCRIPTION
Included lang files for all the spanish-speaking countries:

- es_ar.json - Argentina
- es_cl.json - Chile
- es_ec.json - Ecuador
- es_es.json - Spain
- es_mx.json - Mexico
- es_uy.json - Uruguay
- es_ve.json - Venezuela

Note: Some words were translated differently in some countries so I matched them with their respective official translation.