### PR TITLE
Fix recipes documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To see claim areas, you'll have to craft a *Goggles of (Claim) Revealing*
 
 When this item equipped in the helmet, mainhand or offhand slot, claim outlines become visible.
 
-## [Recipes](https://github.com/Patbox/get-off-my-lawn-reserved/blob/1.19.4/recipes.md)
+## [Recipes](recipes.md)
 
 ## Claim configuration:
 To configure your claim, you can interact with the anchor block. A UI will appear that offers several configuration options:

--- a/recipes.md
+++ b/recipes.md
@@ -27,9 +27,6 @@
 ### Upgrade
 ![](recipes/withered_upgrade_kit.png)
 
-## Glistening Claim Anchor
-![](recipes/glistening_claim_anchor.png)
-
 # Claim Augments
 
 ## Angelic Aura


### PR DESCRIPTION
This PR fixes 2 problems of the documentation:

* The main `README.md` should not link to an outdated `blob/1.19.4/recipes.md`. Instead, it should link to the current `recipes.md` in the same directory. Or would it break the link on the [CurseForge page](https://www.curseforge.com/minecraft/mc-mods/get-off-my-lawn-reserved)?
* `recipes.md` contains the `Glistening Claim Anchor` recipe twice.

Other than that, good job! Thanks for the plugin :)