### PR TITLE
match owners and members of claims to those of originClaims instead of its own

### DIFF
--- a/src/main/java/draylar/goml/api/ClaimUtils.java
+++ b/src/main/java/draylar/goml/api/ClaimUtils.java
@@ -235,9 +235,9 @@ public class ClaimUtils {
             player = playerEntity;
         } else if (attacker instanceof ProjectileEntity projectileEntity && projectileEntity.getOwner() instanceof PlayerEntity playerEntity) {
             player = playerEntity;
-        } else if (attacker instanceof AreaEffectCloudEntity projectileEntity && projectileEntity.getOwner() instanceof PlayerEntity playerEntity) {
+        } else if (attacker instanceof AreaEffectCloudEntity areaEffectCloudEntity && areaEffectCloudEntity.getOwner() instanceof PlayerEntity playerEntity) {
             player = playerEntity;
-        } else if (attacker instanceof TameableEntity projectileEntity && projectileEntity.getOwner() instanceof PlayerEntity playerEntity) {
+        } else if (attacker instanceof TameableEntity tameableEntity && tameableEntity.getOwner() instanceof PlayerEntity playerEntity) {
             player = playerEntity;
         } else if (!(entity instanceof PlayerEntity) && source != null && (attacker == null || source == attacker)) {
             return hasMatchingClaims(world, entity.getBlockPos(), ((OriginOwner) source).goml$getOriginSafe());
@@ -471,7 +471,7 @@ public class ClaimUtils {
             trusted.add(uuid);
         }
 
-        claims.forEach(x -> {
+        originClaims.forEach(x -> {
             trusted.addAll(x.getValue().getOwners());
             trusted.addAll(x.getValue().getTrusted());
         });


### PR DESCRIPTION
`hasMatchingClaims()` returns false `if (originClaims.isEmpty() && uuid == null)`.  In the lines following that, `trusted` is filled with the UUIDs of the owners and members of `claims` and in the end the method returns `claims.anyMatch(x -> x.getValue().hasPermission(trusted))` which is a long way of expressing `true` because as soon as there is one claim to look at, the UUID of its owner will match.  So I believe `trusted` should be filled with the UUIDs of the owners and members of `originClaims` instead.