### PR TITLE
Fix overlapping flight anchors

### DIFF
--- a/src/main/java/draylar/goml/block/augment/HeavenWingsAugmentBlock.java
+++ b/src/main/java/draylar/goml/block/augment/HeavenWingsAugmentBlock.java
@@ -1,5 +1,9 @@
 package draylar.goml.block.augment;
 
+import java.util.Map;
+import java.util.HashMap;
+import java.util.UUID;
+
 import draylar.goml.block.SelectiveClaimAugmentBlock;
 import io.github.ladysnake.pal.AbilitySource;
 import io.github.ladysnake.pal.Pal;
@@ -9,6 +13,7 @@ import net.minecraft.entity.player.PlayerEntity;
 public class HeavenWingsAugmentBlock extends SelectiveClaimAugmentBlock {
 
     public static final AbilitySource HEAVEN_WINGS = Pal.getAbilitySource("goml", "heaven_wings");
+    private static final Map<UUID, Integer> flightReferences = new HashMap<>();
 
     public HeavenWingsAugmentBlock(Settings settings, String texture) {
         super("heaven_wings", settings, texture);
@@ -16,11 +21,25 @@ public class HeavenWingsAugmentBlock extends SelectiveClaimAugmentBlock {
 
     @Override
     public void applyEffect(PlayerEntity player) {
-        HEAVEN_WINGS.grantTo(player, VanillaAbilities.ALLOW_FLYING);
+        UUID playerId = player.getUuid();
+        int currentRefs = flightReferences.getOrDefault(playerId, 0);
+        flightReferences.put(playerId, currentRefs + 1);
+
+        if (currentRefs == 0) {
+            HEAVEN_WINGS.grantTo(player, VanillaAbilities.ALLOW_FLYING);
+        }
     }
 
     @Override
     public void removeEffect(PlayerEntity player) {
-        HEAVEN_WINGS.revokeFrom(player, VanillaAbilities.ALLOW_FLYING);
+        UUID playerId = player.getUuid();
+        int currentRefs = flightReferences.getOrDefault(playerId, 0);
+
+        if (currentRefs > 1) {
+            flightReferences.put(playerId, currentRefs - 1);
+        } else {
+            flightReferences.remove(playerId);
+            HEAVEN_WINGS.revokeFrom(player, VanillaAbilities.ALLOW_FLYING);
+        }
     }
 }


### PR DESCRIPTION
Fixes #41, an issue I've personally become quite annoyed by.

This ensures a premature removal of the wings ability doesn't happen when two+ anchors are close together or overlapping.

Basically, this implementation keeps track of how many times a player has had the flight given to them (implying how many overlapping anchors are providing them the ability) and only when it becomes zero does it remove the ability. 

What would happen before this fix, is when moving out of an anchor that gives the flight ability — but still also being in another that provides it — you would lose it entirely. You would need to leave _both_ anchors range then reenter only one to get it again. 


